### PR TITLE
Add iPXE support, port configuration, and minor bugfix and enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM fedora
-RUN dnf install -y jq dnsmasq syslinux-tftpboot findutils p7zip-plugins procps-ng sed shim-x64
+RUN dnf install -y \
+    dnsmasq \
+    findutils \
+    ipxe-bootimgs \
+    jq \
+    p7zip-plugins \
+    procps-ng \
+    sed \
+    shim-x64 \
+    syslinux-tftpboot
 RUN mkdir -p /data/iso /tmp/mnt /tftpboot/pxelinux.cfg /tftpboot/uefi
 
 ADD files/pxelinux.cfg /data/pxelinux.cfg

--- a/files/iso2pxe.sh
+++ b/files/iso2pxe.sh
@@ -15,6 +15,7 @@ tftp_path=/tftpboot
 iso_paths=/data/iso
 cp /boot/efi/EFI/fedora/shimx64.efi /boot/efi/EFI/fedora/grubx64.efi ${tftp_path}/uefi
 chmod 777 ${tftp_path}/uefi/*
+cp /usr/share/ipxe/ipxe.lkrn ${tftp_path}
 cp /data/pxelinux.cfg ${tftp_path}/pxelinux.cfg/default
 cp /data/grub.cfg ${tftp_path}/uefi/grub.cfg
 for iso in $(find ${iso_paths} -name '*.iso'); do
@@ -27,10 +28,18 @@ for iso in $(find ${iso_paths} -name '*.iso'); do
   echo "LABEL ${isoname}" >> ${tftp_path}/pxelinux.cfg/default
   echo "  KERNEL ${isoname}/vmlinuz" >> ${tftp_path}/pxelinux.cfg/default
   echo "  APPEND initrd=${isoname}/initrd.img,${isoname}/rootfs.img ignition.config.url=http://${webserver}/${isoname}/config.ign ignition.firstboot ignition.platform.id=metal" >> ${tftp_path}/pxelinux.cfg/default
+  echo "LABEL ${isoname} iPXE" >> ${tftp_path}/pxelinux.cfg/default
+  echo "  KERNEL ipxe.lkrn" >> ${tftp_path}/pxelinux.cfg/default
+  echo "  APPEND dhcp && chain http://${webserver}/${isoname}/ipxe" >> ${tftp_path}/pxelinux.cfg/default
   echo "menuentry '${isoname}' {" >> ${tftp_path}/uefi/grub.cfg
   echo "  linux ${isoname}/vmlinuz coreos.live.rootfs_url=http://${webserver}/${isoname}/rootfs.img ignition.config.url=http://${webserver}/${isoname}/config.ign ignition.firstboot ignition.platform.id=metal" >> ${tftp_path}/uefi/grub.cfg
   echo "  initrd ${isoname}/initrd.img" >> ${tftp_path}/uefi/grub.cfg
   echo "}" >> ${tftp_path}/uefi/grub.cfg
+  echo '#!ipxe' >> ${tftp_path}/${isoname}/ipxe
+  echo "set web http://${webserver}/${isoname}"  >> ${tftp_path}/${isoname}/ipxe
+  echo 'kernel ${web}/vmlinuz coreos.live.rootfs_url=${web}/rootfs.img ignition.config.url=${web}/config.ign ignition.firstboot ignition.platform.id=metal'  >> ${tftp_path}/${isoname}/ipxe
+  echo 'initrd ${web}/initrd.img'  >> ${tftp_path}/${isoname}/ipxe
+  echo 'boot'  >> ${tftp_path}/${isoname}/ipxe
 done
 
 start_dhcp=$(echo ${hypervisor} | awk -F. '{print $1"."$2"."$3}').$(($(echo ${hypervisor} | awk -F. '{print $4}') + 1))

--- a/files/iso2pxe.sh
+++ b/files/iso2pxe.sh
@@ -12,6 +12,7 @@ dnsmasq_port=${dnsmasq_port:-53}
 webserver_port=${webserver_port:-8000}
 webserver=${hypervisor}:${webserver_port}
 bind_interface=${interface:-*}
+extra_kernel_args=${extra_kernel_args:-}
 pxe_mount=/tmp/mnt
 tftp_path=/tftpboot
 iso_paths=/data/iso
@@ -29,17 +30,17 @@ for iso in $(find ${iso_paths} -name '*.iso'); do
   7z e ${iso} -so images/ignition.img | gzip -dc | cpio -ivD ${tftp_path}/${isoname}
   echo "LABEL ${isoname}" >> ${tftp_path}/pxelinux.cfg/default
   echo "  KERNEL ${isoname}/vmlinuz" >> ${tftp_path}/pxelinux.cfg/default
-  echo "  APPEND initrd=${isoname}/initrd.img,${isoname}/rootfs.img ignition.config.url=http://${webserver}/${isoname}/config.ign ignition.firstboot ignition.platform.id=metal" >> ${tftp_path}/pxelinux.cfg/default
+  echo "  APPEND initrd=${isoname}/initrd.img,${isoname}/rootfs.img ignition.config.url=http://${webserver}/${isoname}/config.ign ignition.firstboot ignition.platform.id=metal $extra_kernel_args" >> ${tftp_path}/pxelinux.cfg/default
   echo "LABEL ${isoname} iPXE" >> ${tftp_path}/pxelinux.cfg/default
   echo "  KERNEL ipxe.lkrn" >> ${tftp_path}/pxelinux.cfg/default
   echo "  APPEND dhcp && chain http://${webserver}/${isoname}/ipxe" >> ${tftp_path}/pxelinux.cfg/default
   echo "menuentry '${isoname}' {" >> ${tftp_path}/uefi/grub.cfg
-  echo "  linux ${isoname}/vmlinuz coreos.live.rootfs_url=http://${webserver}/${isoname}/rootfs.img ignition.config.url=http://${webserver}/${isoname}/config.ign ignition.firstboot ignition.platform.id=metal" >> ${tftp_path}/uefi/grub.cfg
+  echo "  linux ${isoname}/vmlinuz coreos.live.rootfs_url=http://${webserver}/${isoname}/rootfs.img ignition.config.url=http://${webserver}/${isoname}/config.ign ignition.firstboot ignition.platform.id=metal $extra_kernel_args" >> ${tftp_path}/uefi/grub.cfg
   echo "  initrd ${isoname}/initrd.img" >> ${tftp_path}/uefi/grub.cfg
   echo "}" >> ${tftp_path}/uefi/grub.cfg
   echo '#!ipxe' >> ${tftp_path}/${isoname}/ipxe
   echo "set web http://${webserver}/${isoname}"  >> ${tftp_path}/${isoname}/ipxe
-  echo 'kernel ${web}/vmlinuz coreos.live.rootfs_url=${web}/rootfs.img ignition.config.url=${web}/config.ign ignition.firstboot ignition.platform.id=metal'  >> ${tftp_path}/${isoname}/ipxe
+  echo 'kernel ${web}/vmlinuz coreos.live.rootfs_url=${web}/rootfs.img ignition.config.url=${web}/config.ign ignition.firstboot ignition.platform.id=metal' "$extra_kernel_args"  >> ${tftp_path}/${isoname}/ipxe
   echo 'initrd ${web}/initrd.img'  >> ${tftp_path}/${isoname}/ipxe
   echo 'boot'  >> ${tftp_path}/${isoname}/ipxe
 done

--- a/files/iso2pxe.sh
+++ b/files/iso2pxe.sh
@@ -49,7 +49,7 @@ end_dhcp=$(echo ${hypervisor} | awk -F. '{print $1"."$2"."$3}').$(($(echo ${hype
   --dhcp-boot=tag:efi-x86_64,uefi/shimx64.efi \
   --dhcp-boot=tag:bios,pxelinux.0 \
   --conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmorig \
-  --interface ${bind_interface} -z \
+  --interface "${bind_interface}" -z \
   --log-dhcp \
   --listen-address=${hypervisor} &
 /usr/bin/python3 -m http.server --directory ${tftp_path} 8000 &

--- a/files/iso2pxe.sh
+++ b/files/iso2pxe.sh
@@ -8,7 +8,9 @@ if [ -z ${hypervisor} ]; then
   exit
 fi
 
-webserver=${hypervisor}:8000
+dnsmasq_port=${dnsmasq_port:-53}
+webserver_port=${webserver_port:-8000}
+webserver=${hypervisor}:${webserver_port}
 bind_interface=${interface:-*}
 pxe_mount=/tmp/mnt
 tftp_path=/tftpboot
@@ -60,8 +62,9 @@ end_dhcp=$(echo ${hypervisor} | awk -F. '{print $1"."$2"."$3}').$(($(echo ${hype
   --conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmorig \
   --interface "${bind_interface}" -z \
   --log-dhcp \
+  --port ${dnsmasq_port} \
   --listen-address=${hypervisor} &
-/usr/bin/python3 -m http.server --directory ${tftp_path} 8000 &
+/usr/bin/python3 -m http.server --directory ${tftp_path} ${webserver_port} &
 
 while true; do
   pgrep dnsmasq > /dev/null


### PR DESCRIPTION
- Add iPXE support
- Fix shell expansion bug when listen_interface is *
- Allow configuration of http and dnsmaq port numbers (and setting dnsmasq port as 0 disables DNS ... handy sometimes)
- Allow extra kernel parameters (for example, to set up serial console :) )